### PR TITLE
added optional re whitespace before first field of /proc/net/dev

### DIFF
--- a/ProcInfo.py
+++ b/ProcInfo.py
@@ -424,7 +424,7 @@ class ProcInfo(object):
             with open('/proc/net/dev') as fd:
                 line = fd.readline()
                 while line != '':
-                    m = re.match(r"\s*eth(\d):(\d+)\s+\d+\s+(\d+)\s+\d+\s+\d+\s+\d+\s+\d+\s+\d+\s+(\d+)\s+\d+\s+(\d+)", line)
+                    m = re.match(r"\s*eth(\d):\s*(\d+)\s+\d+\s+(\d+)\s+\d+\s+\d+\s+\d+\s+\d+\s+\d+\s+(\d+)\s+\d+\s+(\d+)", line)
                     if m is not None:
                         self.data['raw_eth'+m.group(1)+'_in'] = float(m.group(2))
                         self.data['raw_eth'+m.group(1)+'_out'] = float(m.group(4))


### PR DESCRIPTION
The regular expression for parsing `/proc/net/dev` expects the first field to start directly after the interface identifier. This fails at least on SL6 and SL7, where there is additional whitespace:
```
'  eth1: 340999806392352 531094628497 539488301    0 539474838 13463          0    106228 462386332654824 324117320000    0    0    0     0       0        0\n'
```