### PR TITLE
Network interface totals (apmon_perl port)

### DIFF
--- a/ProcInfo.py
+++ b/ProcInfo.py
@@ -46,7 +46,7 @@ class ProcInfo(object):
         self.lastUpdateTime = 0  # when the last measurement was done
         self.jobs = {}             # jobs that will be monitored
         self.logger = logger	    # use the given logger
-        self.readGenericInfo()
+        self._network_interfaces = set()  # network interfaces to track
 
 
     def update(self):
@@ -63,6 +63,7 @@ class ProcInfo(object):
         self.countProcesses()
         self.readNetworkInfo()
         self.readNetStat()
+        self.readGenericInfo()
         for pid in list(self.jobs.keys()):
             self.readJobInfo(pid)
             self.readJobDiskUsage(pid)

--- a/ProcInfo.py
+++ b/ProcInfo.py
@@ -723,8 +723,8 @@ class ProcInfo(object):
 
         # eth - related params
         for rawParam in list(dataRef.keys()):
-            if (rawParam.find('raw_eth') == 0) and rawParam in prevDataRef:
-                param = rawParam.split('raw_')[1]
+            if (rawParam.find('raw_net_') == 0) and rawParam in prevDataRef:
+                param = rawParam.split('raw_net_')[1]
                 if interval != 0:
                     dataRef[param] = self.diffWithOverflowCheck(dataRef[rawParam], prevDataRef[rawParam])  # absolute difference
                     if param.find('_errs') == -1:
@@ -763,7 +763,7 @@ class ProcInfo(object):
                 netParam = m.group(1)
                 # self.logger.log(Logger.DEBUG, "Querying param "+net_param)
                 for key, value in list(dataHash.items()):
-                    m = re.match(r"eth\d_"+netParam, key)
+                    m = re.match(r"^(\w+)_"+netParam, key)
                     if m is not None:
                         result[key] = value
             else:


### PR DESCRIPTION
This reimplements the network tracking from [apmon_perl](https://github.com/MonALISA-CIT/apmon_perl ):

* network interfaces with arbitrary, non-``eth`` names are supported
* network interfaces which are virtual (loopback, aliases, vlan, ...) are excluded
* sum over all interfaces available as ``total_traffic`` pseudo-interface