### PR TITLE
Examples: cast timestamp to int

### DIFF
--- a/examples/timed_params.py
+++ b/examples/timed_params.py
@@ -17,7 +17,7 @@ import random
 apm = apmon.ApMon(('pcardaab.cern.ch:8884', ))
 
 for i in list(range(1, 20)):
-    my_time = time.time() - 2 * 3600 - (20 - i) * 60
+    my_time = int(time.time() - 2 * 3600 - (20 - i) * 60)
     state = int(random.randint(0, 10))
     # Note that also there's a sendTimedParams version
     apm.sendTimedParameters("LogParser", "SomeApp", my_time, {'state': state})


### PR DESCRIPTION
The timestamp is float, while apmon expects an int.